### PR TITLE
Fix Proposal context import path

### DIFF
--- a/src/context/Proposal.tsx
+++ b/src/context/Proposal.tsx
@@ -13,7 +13,7 @@ import NounProposalCandidateFromSubgraph, {
 import NounProposalFromSubgraph, {
     isNounProposalFromSubgraph,
 } from '@/utils/dto/Noun/Proposal/FromSubgraph';
-import { DaoProxyContext } from '@/context//DaoProxy';
+import { DaoProxyContext } from '@/context/DaoProxy';
 import NounProposalFromContract from '@/utils/dto/Noun/Proposal/FromContract';
 import { LatestBlockContext } from '@/context/LatestBlock';
 


### PR DESCRIPTION
## Summary
- correct DaoProxy import path in Proposal context

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find dependencies)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d0c27d148321b2d387d03823a896