### PR TITLE
Fix typo in dream proposal

### DIFF
--- a/src/utils/dictionaries/en-US/pages/nouns/dreams/dream/propose.json
+++ b/src/utils/dictionaries/en-US/pages/nouns/dreams/dream/propose.json
@@ -32,7 +32,7 @@
                 "placeholder": "Specify ETH amnt"
             }
         },
-        "title": "Would you like to request componsation? This will be sent to the wallet you are proposing from right now."
+        "title": "Would you like to request compensation? This will be sent to the wallet you are proposing from right now."
     },
     "titleAndDescription": {
         "field": {


### PR DESCRIPTION
## Summary
- fix a typo in `propose.json`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f221a93483218e6abf391286bc7b