### PR TITLE
Fix useEffect guard in useNounMint

### DIFF
--- a/src/hooks/useNounMint.ts
+++ b/src/hooks/useNounMint.ts
@@ -12,7 +12,7 @@ const useNounMintBlock = (nounId: number) => {
     const { httpTokenContract: contract } = useContext(TokenContext);
 
     useEffect(() => {
-        if (!contract || !provider || !contract) return;
+        if (!contract || !provider) return;
 
         const fetchTokenTransfers = async () => {
             try {


### PR DESCRIPTION
## Summary
- remove redundant contract check in `useNounMint` guard

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f1f24f348321a5720be54fa3aeb2