### PR TITLE
Rename fetcher for latest block

### DIFF
--- a/src/context/LatestBlock.tsx
+++ b/src/context/LatestBlock.tsx
@@ -20,7 +20,8 @@ const LatestBlockProvider: React.FC<Props> = ({ children }) => {
     const { httpProvider: provider } = useContext(RpcContext);
 
     useEffect(() => {
-        async function fetchCurrentVotes() {
+        // Fetch the latest block information
+        async function fetchLatestBlock() {
             if (!provider) return;
 
             setLatestBlock(undefined);
@@ -28,7 +29,7 @@ const LatestBlockProvider: React.FC<Props> = ({ children }) => {
             try {
                 const block = await provider.getBlock('latest');
 
-                // Example
+                // Example latest block data
                 // baseFeePerGas: 372827101n
                 // blobGasUsed: 262144n
                 // difficulty: 0n
@@ -62,7 +63,7 @@ const LatestBlockProvider: React.FC<Props> = ({ children }) => {
             }
         }
 
-        fetchCurrentVotes();
+        fetchLatestBlock();
     }, [provider]);
 
     return (


### PR DESCRIPTION
## Summary
- rename the helper inside `LatestBlock` context to `fetchLatestBlock`
- update the call site and comment to match new name
- clarify comment about sample data

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f234191483219a89886a5cf0e568